### PR TITLE
Support a more flexible data API

### DIFF
--- a/app/scripts/controllers/main.coffee
+++ b/app/scripts/controllers/main.coffee
@@ -3,6 +3,9 @@ angular.module('angularD3App').controller 'MainCtrl', ($scope) ->
   $scope.xvalues = [0..5]
   $scope.yvalues = [0..10]
   $scope.y2values = [0..5]
-  $scope.line = [[0,1],[1,2],[3,1],[4,6],[5,0]]
+
+  $scope.line = for value in [[0,1],[1,2],[3,1],[4,6],[5,0]]
+    { age: value[0], savings: value[1] }
+
   $scope.area = [[0,0.5],[1,1],[3,2],[4,4],[5,8]]
   $scope.bar = [[1,3],[2,2],[3,1],[4,4]]

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -11,7 +11,7 @@
         <d3-axis name="yaxis" domain="yvalues" label="Y Values" orientation="left" ticks="5"></d3-axis>
         <d3-axis name="y2axis" domain="yvalues" label="Y2 Values" orientation="right" ticks="5"></d3-axis>
         <d3-area data="area" xscale="xaxis" yscale="yaxis"></d3-area>
-        <d3-line data="line" xscale="xaxis" yscale="yaxis"></d3-line>
+        <d3-line data="line" x="age" y="savings" xscale="xaxis" yscale="yaxis"></d3-line>
         <d3-bars data="bar" xscale="xaxis" yscale="y2axis"></d3-bar>
       </d3-chart>
     </div>

--- a/src/angularD3/directives/area.coffee
+++ b/src/angularD3/directives/area.coffee
@@ -1,4 +1,8 @@
 angular.module('ad3').directive 'd3Area', () ->
+  defaults = ->
+    x: 0
+    y: 1
+
   scope:
     data: '='
 
@@ -7,17 +11,18 @@ angular.module('ad3').directive 'd3Area', () ->
   require: '^d3Chart'
 
   link: (scope, el, attrs, chartController) ->
-    x = chartController.getScale(attrs.xscale)
-    y = chartController.getScale(attrs.yscale)
+    options = angular.extend(defaults(), attrs)
+    x = chartController.getScale(options.xscale)
+    y = chartController.getScale(options.yscale)
     height = chartController.innerHeight()
     areaStart = d3.svg.area()
-      .x((d) -> x(d[0]))
+      .x((d) -> x(d[options.x]))
       .y0(height)
       .y1(height)
     area = d3.svg.area()
-      .x((d) -> x(d[0]))
+      .x((d) -> x(d[options.x]))
       .y0(height)
-      .y1((d) -> y(d[1]))
+      .y1((d) -> y(d[options.y]))
     chartController.getChart().append("path").attr("class", "area")
       .attr("style", "fill: #FF3030; stroke: #FF3030; opacity: 0.8")
       .datum(scope.data)

--- a/src/angularD3/directives/axis.coffee
+++ b/src/angularD3/directives/axis.coffee
@@ -1,5 +1,5 @@
 angular.module('ad3').directive 'd3Axis', ->
-  defaults =
+  defaults = ->
     orientation: 'bottom'
     label: 'X-Axis'
     ticks: '5'
@@ -15,62 +15,61 @@ angular.module('ad3').directive 'd3Axis', ->
   require: '^d3Chart'
 
   link: (scope, el, attrs, chartController) ->
-    attrs = angular.extend(defaults, attrs)
+    options = angular.extend(defaults(), attrs)
 
-    console.log(chartController.innerWidth())
     range = ->
-      if attrs.orientation is 'top' or attrs.orientation is 'bottom'
+      if options.orientation is 'top' or options.orientation is 'bottom'
         [0 ,chartController.innerWidth()]
       else
         [chartController.innerHeight(), 0]
 
     translation = ->
-      if attrs.orientation is 'bottom'
+      if options.orientation is 'bottom'
         "translate(0, #{chartController.innerHeight()})"
-      else if attrs.orientation is 'top'
+      else if options.orientation is 'top'
         "translate(0, 0)"
-      else if attrs.orientation is 'left'
+      else if options.orientation is 'left'
         "translate(0, 0)"
-      else if attrs.orientation is 'right'
+      else if options.orientation is 'right'
         "translate(#{chartController.innerWidth()}, 0)"
 
     scale = d3.scale.linear()
     scale.range(range())
     scale.domain d3.extent scope.domain
-    chartController.addScale(attrs.name, scale)
+    chartController.addScale(options.name, scale)
 
-    xAxis = d3.svg.axis().scale(scale).orient(attrs.orientation)
-      .ticks(attrs.ticks)
+    xAxis = d3.svg.axis().scale(scale).orient(options.orientation)
+      .ticks(options.ticks)
 
-    if attrs.format
-      format = d3.format(attrs.format)
+    if options.format
+      format = d3.format(options.format)
       xAxis.tickFormat(format)
 
     # Append x-axis to chart
     axis = chartController.getChart().append("g")
-      .attr("class", "#{attrs.orientation} axis")
+      .attr("class", "#{options.orientation} axis")
       .attr("transform", translation())
 
     positionLabel = (label) ->
-      if attrs.orientation is 'bottom'
+      if options.orientation is 'bottom'
         label
           .attr("x", "#{chartController.innerWidth() / 2}")
           .attr("dy", "2.5em").attr("style", "text-anchor: middle;")
-      else if attrs.orientation is 'top'
+      else if options.orientation is 'top'
         label.attr("x", "#{chartController.innerWidth() / 2}")
           .attr("dy", "-1.5em").attr("style", "text-anchor: middle;")
-      else if attrs.orientation is 'left'
+      else if options.orientation is 'left'
         label.attr("dy", "-2.5em")
           .attr("x", "-#{chartController.innerHeight() / 2}")
           .attr("style", "text-anchor: middle;")
           .attr("transform", "rotate(-90)")
-      else if attrs.orientation is 'right'
+      else if options.orientation is 'right'
         label.attr("dy", "-2.5em")
           .attr("x", "#{chartController.innerHeight() / 2}")
           .attr("style", "text-anchor: middle;")
           .attr("transform", "rotate(90)")
 
-    label = axis.append("text").attr("class", "axis-label").text(attrs.label)
+    label = axis.append("text").attr("class", "axis-label").text(options.label)
     positionLabel(label)
 
     axis.call(xAxis)

--- a/src/angularD3/directives/bars.coffee
+++ b/src/angularD3/directives/bars.coffee
@@ -1,4 +1,8 @@
 angular.module('ad3').directive 'd3Bars', () ->
+  defaults = ->
+    x: 0
+    y: 1
+
   scope:
     data: '='
 
@@ -7,8 +11,9 @@ angular.module('ad3').directive 'd3Bars', () ->
   require: '^d3Chart'
 
   link: (scope, el, attrs, chartController) ->
-    x = chartController.getScale(attrs.xscale)
-    y = chartController.getScale(attrs.yscale)
+    options = angular.extend(defaults(), attrs)
+    x = chartController.getScale(options.xscale)
+    y = chartController.getScale(options.yscale)
     chart = chartController.getChart()
     height = chartController.innerHeight()
     width = 20
@@ -18,16 +23,16 @@ angular.module('ad3').directive 'd3Bars', () ->
       .attr("height", 0)
       .remove()
     bars.transition().duration(500)
-      .attr("x", (d) -> x(d[0]) - width/2)
-      .attr("y", (d) -> y(d[1]))
-      .attr("height", (d) -> height - y(d[1]))
+      .attr("x", (d) -> x(d[options.x]) - width/2)
+      .attr("y", (d) -> y(d[options.y]))
+      .attr("height", (d) -> height - y(d[options.y]))
       .attr("width", width)
     bars.enter()
       .append("rect")
-      .attr("x", (d) -> x(d[0]) - width/2)
+      .attr("x", (d) -> x(d[options.x]) - width/2)
       .attr("width", width)
       .attr("y", height)
       .attr("height", 0)
       .transition().duration(500)
-      .attr("y", (d) -> y(d[1]))
-      .attr("height", (d) -> height - y(d[1]))
+      .attr("y", (d) -> y(d[options.y]))
+      .attr("height", (d) -> height - y(d[options.y]))

--- a/src/angularD3/directives/line.coffee
+++ b/src/angularD3/directives/line.coffee
@@ -1,4 +1,8 @@
 angular.module('ad3').directive 'd3Line', ->
+  defaults = ->
+    x: 0
+    y: 1
+
   scope:
     data: '='
 
@@ -7,16 +11,17 @@ angular.module('ad3').directive 'd3Line', ->
   require: '^d3Chart'
 
   link: (scope, el, attrs, chartController) ->
-    x = chartController.getScale(attrs.xscale)
-    y = chartController.getScale(attrs.yscale)
+    options = angular.extend(defaults(), attrs)
+    x = chartController.getScale(options.xscale)
+    y = chartController.getScale(options.yscale)
     height = chartController.innerHeight()
     lineStart = d3.svg.line()
-      .x((d) -> x(d[0]))
+      .x((d) -> x(d[options.x]))
       .y(height)
     line = d3.svg.line()
-      .x((d) -> x(d[0]))
-      .y((d) -> y(d[1]))
-    chartController.getChart().append("path").attr("class", "line")
+      .x((d) -> x(d[options.x]))
+      .y((d) -> y(d[options.y]))
+    graph = chartController.getChart().append("path").attr("class", "line")
       .attr("style", "fill: none; stroke-width: 2px; stroke: #3030FF")
       .datum(scope.data)
       .attr("d", lineStart)


### PR DESCRIPTION
Add support for object data maps where the property names for x and y
can be specified using attributes. Falls back to coordinate support if
no property names are specified.
