### PR TITLE
# adding arc.coffee to be able to create simple arc representations

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -46,11 +46,11 @@
 
     <script src="components/d3/d3.js"></script>
     <script src="components/angular-unstable/angular.js"></script>
-    <script src="components/angular-resource/angular-resource.js"></script>
-    <script src="components/angular-cookies/angular-cookies.js"></script>
-    <script src="components/angular-sanitize/angular-sanitize.js"></script>
+    <!--<script src="components/angular-resource/angular-resource.js"></script>-->
+    <!--<script src="components/angular-cookies/angular-cookies.js"></script>-->
+    <!--<script src="components/angular-sanitize/angular-sanitize.js"></script>-->
     <script src="components/jquery/jquery.min.js"></script>
-    <script src="components/bootstrap/js/bootstrap-affix.js"></script>
+    <!--<script src="components/bootstrap/js/bootstrap-affix.js"></script>-->
 
     <!-- build:js angularD3/angularD3.js -->
     <script src="angularD3/angularD3.js"></script>
@@ -62,7 +62,7 @@
     <script src="angularD3/directives/area.js"></script>
     <script src="angularD3/directives/data.js"></script>
     <script src="angularD3/directives/pie.js"></script>
-
+    <script src="angularD3/directives/arc.js"></script>
 
     <!-- endbuild -->
 

--- a/app/styles/theme/default.scss
+++ b/app/styles/theme/default.scss
@@ -49,3 +49,11 @@ svg.d3 {
   .arc.arc-5 path { fill: #d0743c; }
   .arc.arc-6 path { fill: #ff8c00; }
 }
+
+/* Simple Arcss */
+svg.d3.simple-arc1 path {
+    fill: #98abc5;
+}
+svg.d3.simple-arc2 path {
+    fill: #d0743c;
+}

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -20,7 +20,15 @@
       <d3-pie data="pie" value="age" amount="population"></d3-pie>
     </d3-chart>
     <d3-chart height="320" class="span6">
-      <d3-pie inner-radius="0.5" label-radius="1.1" data="pie" value="age" amount="population"></d3-pie>
+      <d3-pie inner-radius="0.5" label-radius="0" data="pie" value="age" amount="population"></d3-pie>
+    </d3-chart>
+  </div>
+  <div class="row">
+    <d3-chart height="320" class="span6 simple-arc1">
+      <d3-arc inner-radius="0.5"  data="{{ {percentVal:60, text:'60%'}  }}" label="text" amount="percentVal" transition="bounce" transition-duration="1000"></d3-arc>
+    </d3-chart>
+    <d3-chart height="320" class="span6 simple-arc2">
+      <d3-arc inner-radius="0.5"  data="{{ {percentVal:90, text:'90%'}  }}" label="text" amount="percentVal"></d3-arc>
     </d3-chart>
   </div>
 </section>

--- a/src/angularD3/directives/arc.coffee
+++ b/src/angularD3/directives/arc.coffee
@@ -1,0 +1,71 @@
+angular.module('ad3').directive 'd3Arc', () ->
+  defaults = ->
+    x: 0
+    y: 1
+    innerRadius: 0
+    labelRadius: 0
+    transition: "cubic-in-out"
+    transitionDuration: 1000
+
+  restrict: 'E'
+
+  require: '^d3Chart'
+
+  link: (scope, el, attrs, chartController) ->
+    options = angular.extend(defaults(), attrs)
+
+    chart = chartController.getChart()
+    height = chartController.innerHeight()
+    width = chartController.innerWidth()
+    innerRadius = parseFloat(options.innerRadius)
+    labelRadius = parseFloat(options.labelRadius)
+
+    radius = Math.min(width,height) / 2
+
+    arc = d3.svg.arc()
+      .outerRadius(radius)
+      .innerRadius(radius * innerRadius)
+      .startAngle(0)
+      .endAngle( (d) -> d.value/100 * 2 * Math.PI )
+
+    labelArc = d3.svg.arc()
+      .outerRadius(radius * labelRadius)
+      .innerRadius(radius * labelRadius)
+
+    width = chartController.innerWidth()
+    height = chartController.innerHeight()
+
+    center = chartController.getChart()
+      .append("svg:g")
+      .attr("transform", "translate(" + width / 2  + "," + height / 2 + ")")
+
+    arcTween = (b) ->
+      i = d3.interpolate({value: 0}, b)
+      (t) ->
+         arc(i(t))
+
+    draw = (data, old, scope) ->
+      return unless data?
+     
+      path = center.selectAll("path")
+        .data([{"value":data[options.amount]}])
+
+      path.enter().append("svg:path")
+        .transition()
+          .ease(options.transition)
+          .duration(options.transitionDuration)
+          .attrTween("d", arcTween)
+
+      path.transition()
+          .ease(options.transition)
+          .duration(options.transitionDuration)
+          .attrTween("d", arcTween)
+
+      path.enter().append("svg:text")
+        .attr("transform", (d) -> "translate(" + labelArc.centroid(d) + ")")
+        .attr("dy", "0.35em")
+        .style("text-anchor", "middle")
+        .text(data[options.label])
+
+
+    scope.$watch attrs.data, draw , true


### PR DESCRIPTION
here's a patch that adds support to build simple gauge-arc representation. I've also updated the main.html to include 2 of these samples:

```
<d3-chart height="320" class="span6 simple-arc1">
  <d3-arc inner-radius="0.5"  data="{{ {percentVal:60, text:'60%'}  }}" label="text" amount="percentVal" transition="bounce" transition-duration="1000"></d3-arc>
</d3-chart>
<d3-chart height="320" class="span6 simple-arc2">
  <d3-arc inner-radius="0.5"  data="{{ {percentVal:90, text:'90%'}  }}" label="text" amount="percentVal"></d3-arc>
</d3-chart>
```
